### PR TITLE
Make library go 1.20 compatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cryptera-device-security/libpkcs11ks
 
-go 1.23.2
+go 1.20
 
 require (
 	github.com/miekg/pkcs11 v1.1.1

--- a/hsm.go
+++ b/hsm.go
@@ -14,7 +14,7 @@ type pkcsObject []*pkcs11.Attribute
 func toBytes(value int, size int) []byte {
 	b := make([]byte, size)
 
-	for i := range size {
+	for i := 0; i < size; i++ {
 		b[size-i-1] = byte(value)
 		value >>= 8
 	}


### PR DESCRIPTION
This removes the use of functionallity which requires Go 1.22 or newer